### PR TITLE
[FIX] project_timeline: Allow to install this module with project_ent…

### DIFF
--- a/project_timeline/report/project_report.py
+++ b/project_timeline/report/project_report.py
@@ -11,18 +11,33 @@ class ReportProjectTaskUser(models.Model):
     planned_date_end = fields.Datetime(readonly=True)
 
     def _select(self):
+        res = super()._select()
+        if "planned_date_end" in res:
+            return (
+                res
+                + """,
+            t.planned_date_start"""
+            )
         return (
-            super()._select()
+            res
             + """,
-            t.planned_date_start,
-            t.planned_date_end"""
+            t.planned_date_start as planned_date_start,
+            t.planned_date_end as planned_date_end
+        """
         )
 
     def _group_by(self):
+        res = super()._group_by()
+        if "planned_date_end" in res:
+            return (
+                res
+                + """,
+            t.planned_date_start"""
+            )
         return (
-            super()._group_by()
+            res
             + """,
-            t.planned_date_start,
-            t.planned_date_end
-            """
+            planned_date_start,
+            planned_date_end
+        """
         )


### PR DESCRIPTION
…erprise

This PR fixes an issue added in commit
https://github.com/OCA/project/commit/3689f1dfccf755c5d862c0e779ab0364215dea3a

When the module project_timeline is installed in a database with the module project_enterprise, it raises the following error:

psycopg2.errors.DuplicateColumn: column "planned_date_end" specified more than once

This is because the field planned_date_end is defined in both modules.

This PR checks if the field is already defined in the query before adding it.